### PR TITLE
feat: Add Discord relay webhook and enhance message relay functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glineze-node-typescript",
-  "version": "2.1.7",
+  "version": "2.2.0",
   "description": "",
   "main": "dist/app.js",
   "type": "commonjs",

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export const config = {
   discord: {
     botToken: validateEnvVar(process.env.DISCORD_BOT_TOKEN, 'DISCORD_BOT_TOKEN'),
     webHook: validateEnvVar(process.env.DISCORD_ERROR_LOG_WEBHOOK, 'DISCORD_ERROR_LOG_WEBHOOK'),
+    relayWebhook: validateEnvVar(process.env.DISCORD_RELAY_WEBHOOK, 'DISCORD_RELAY_WEBHOOK'),
   },
   notion: {
     token: validateEnvVar(process.env.NOTION_TOKEN, 'NOTION_TOKEN'),

--- a/src/services/discord/discordWebhook.ts
+++ b/src/services/discord/discordWebhook.ts
@@ -1,15 +1,66 @@
-import axios from 'axios';
+import {
+  ChannelType,
+  Message,
+  TextChannel,
+  ThreadChannel,
+  User,
+  VoiceChannel,
+  WebhookClient,
+} from 'discord.js';
+import { config } from '../../config';
+import { logger } from '../../utils/logger';
 
-export async function sendDiscordWebhookMessage(
-  webhookUrl: string,
-  message: string
-): Promise<void> {
-  const payload = {
-    content: message,
-  };
-
-  await axios.post(webhookUrl, payload).catch((err) => {
-    // logger.error をすると無限ループになる可能性があるので console.error でエラーを出力
-    console.error('Error in sendMessageToDiscordChannel: ' + err);
+export async function relayMessageToDiscordWebhook(message: Message): Promise<void> {
+  const webhookClient = new WebhookClient({
+    url: config.discord.relayWebhook,
   });
+
+  try {
+    if (
+      message.channel.type === ChannelType.DM ||
+      message.channel.type === ChannelType.GuildText ||
+      message.channel.type === ChannelType.GuildVoice ||
+      message.channel.type === ChannelType.PrivateThread ||
+      message.channel.type === ChannelType.PublicThread
+    ) {
+      const messageText = message.cleanContent;
+      const messageAuthor = await getMessageAuthor(message.author);
+
+      const messageTitle =
+        message.channel.type === ChannelType.DM
+          ? `DM - ${messageAuthor.username}`
+          : createMessageTitle(message.channel) + ` - ${messageAuthor.username}:`;
+
+      const attachments = message.attachments.map((attachment) => attachment.url);
+
+      await webhookClient.send({
+        content: messageText,
+        username: messageTitle,
+        avatarURL: messageAuthor.displayAvatarURL(),
+        files: attachments,
+      });
+    } else {
+      logger.info(`メッセージの転送対象外: 不明なチャンネルタイプ ${message.channel.type}`);
+      return;
+    }
+  } catch (error) {
+    logger.error(`メッセージの転送中にエラーが発生: ${error}`);
+  }
+}
+
+function createMessageTitle(channel: TextChannel | VoiceChannel | ThreadChannel): string {
+  let title = `${channel.guild.name}: #`;
+
+  if (channel.isThread() && channel.parent) {
+    title += `${channel.parent.name} > `;
+  }
+
+  return title + channel.name;
+}
+
+async function getMessageAuthor(author: User): Promise<User> {
+  if (author.partial) {
+    return await author.fetch();
+  }
+  return author;
 }

--- a/src/services/lineNotifyService.ts
+++ b/src/services/lineNotifyService.ts
@@ -1,6 +1,4 @@
 import axios from 'axios';
-import { CONSTANTS } from '../constants';
-import { logger } from '../utils/logger';
 import {
   Attachment,
   ChannelType,
@@ -12,6 +10,8 @@ import {
   VoiceChannel,
 } from 'discord.js';
 import { config } from '../config';
+import { CONSTANTS } from '../constants';
+import { logger } from '../utils/logger';
 import { LINEDiscordPairService } from './notion/lineDiscordPairService';
 interface AttachmentInfo {
   isImage: boolean;


### PR DESCRIPTION
- Added `relayWebhook` configuration in `config.ts` for Discord message relay
- Implemented `relayMessageToDiscordWebhook` in `discordWebhook.ts` to support comprehensive message relaying
- Updated `MessageHandler` to use the new webhook relay method for both DM and guild messages
- Introduced utility functions in `discordWebhook.ts` to handle message title and author formatting
- Bumped version to 2.2.0 to reflect the new feature