### PR TITLE
chore: Update default application port to 10000

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ export const config = {
     channelAccessToken: process.env.LINEBOT_CHANNEL_ACCESS_TOKEN || '',
   },
   app: {
-    port: Number(process.env.PORT) || 3001,
+    port: Number(process.env.PORT) || 10000,
   },
   repository: {
     path: process.env.REPOSITORY_PATH || '',


### PR DESCRIPTION
- Modified the default port in `config.ts` from 3001 to 10000
- Ensures consistent port configuration when no explicit PORT environment variable is set