### PR TITLE
chore: Add initialization logging to services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glineze-node-typescript",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "dist/app.js",
   "type": "commonjs",

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ const initializeServices = async () => {
   try {
     // config の初期化
     await config.initializeConfig();
+
     // NotionService
     const notionService = new NotionService();
 

--- a/src/services/discord/discordService.ts
+++ b/src/services/discord/discordService.ts
@@ -25,6 +25,8 @@ export class DiscordService {
   private readonly services: Services;
 
   constructor(_services: { notion: NotionService; sesame: SesameService }) {
+    console.log('DiscordService の初期化を開始します。');
+
     // インスタンスを格納
     this.services = {
       notion: _services.notion,
@@ -60,6 +62,8 @@ export class DiscordService {
 
     // イベントリスナーを初期化
     this.initializeEventListeners();
+
+    console.log('DiscordService の初期化が終了しました。');
   }
 
   private initializeEventListeners(): void {

--- a/src/services/notion/notionService.ts
+++ b/src/services/notion/notionService.ts
@@ -10,6 +10,8 @@ export class NotionService {
   public shukinService: ShukinService;
 
   constructor() {
+    console.log('NotionService の初期化を開始します。');
+
     const NOTION_TOKEN = process.env.NOTION_TOKEN;
 
     if (!NOTION_TOKEN) {
@@ -20,5 +22,7 @@ export class NotionService {
     this.memberService = new MemberService(this.client);
     this.practiceService = new PracticeService(this.client);
     this.shukinService = new ShukinService(this.client);
+
+    console.log('NotionService の初期化が終了しました。');
   }
 }

--- a/src/services/sesame/sesameService.ts
+++ b/src/services/sesame/sesameService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { config } from '../../config';
 import {
   SesameAPIResponse,
   SesameDeviceStatus,
@@ -6,7 +7,6 @@ import {
   SesameLockStatus,
 } from '../../types/types';
 import { logger } from '../../utils/logger';
-import { config } from '../../config';
 export class SesameService {
   private sesameApiUrl = '';
   private sesameApiToken = '';
@@ -14,6 +14,8 @@ export class SesameService {
   private sesamePublicKey = '';
 
   constructor() {
+    console.log('SesameService の初期化を開始します。');
+
     this.sesameApiUrl = config.getConfig('sesame_app_api_url');
     this.sesameApiToken = config.getConfig('sesame_app_api_key');
     this.sesameDeviceUUID = config.getConfig('sesame_device_uuid');
@@ -27,6 +29,8 @@ export class SesameService {
     ) {
       throw new Error('Configuration not found for Sesame API');
     }
+
+    console.log('SesameService の初期化が終了しました。');
   }
 
   public async getSesameDeviceStatus(): Promise<SesameDeviceStatus> {

--- a/src/services/webapi/webServerService.ts
+++ b/src/services/webapi/webServerService.ts
@@ -13,6 +13,8 @@ export class WebServerService {
   private notionAutomation: NotionAutomationService;
 
   constructor(private readonly services: Services) {
+    console.log('WebServerService の初期化を開始します。');
+
     this.notionAutomation = new NotionAutomationService(services);
 
     this.app = express();
@@ -20,6 +22,8 @@ export class WebServerService {
 
     this.setupAPIEndpoints();
     this.start();
+
+    console.log('WebServerService の初期化が終了しました。');
   }
 
   private setupAPIEndpoints() {
@@ -61,6 +65,8 @@ export class WebServerService {
    * サーバーの起動
    */
   private start() {
+    console.log('Glineze API サーバーの起動を試みます……');
+
     const port = config.app.port;
     this.app.listen(port, () => {
       logger.info(`Glineze API サーバーがポート ${port} で起動しました`);


### PR DESCRIPTION
- Added console log messages to track the initialization process of various services
- Logged start and end of initialization for DiscordService, NotionService, SesameService, and WebServerService
- Bumped version to 2.3.1 to reflect the logging enhancements