### PR TITLE
refactor: Adjust Discord message handling logic for guild filtering

### DIFF
--- a/src/services/discord/messageHandler.ts
+++ b/src/services/discord/messageHandler.ts
@@ -14,13 +14,12 @@ export class MessageHandler {
   public async handleMessageCreate(message: Message) {
     if (message.author.bot) return;
 
-    if (message.guild.id === process.env.DISCORD_VOID_GUILD_ID) return;
-
     console.log(message);
 
     if (message.channel.type === ChannelType.DM) {
       await this.handleDMMessage(message);
     } else if (message.channel) {
+      if (message.guild.id === process.env.DISCORD_VOID_GUILD_ID) return;
       await this.handleGuildMessage(message);
     }
   }


### PR DESCRIPTION
- Moved guild ID check after DM channel check to ensure proper message processing
- Prevent processing messages from the specified void guild before other channel type checks