### PR TITLE
refactor: セサミのステータスメッセージ関数名を更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glineze-node-typescript",
-  "version": "2.3.2",
+  "version": "2.3.8a",
   "description": "",
   "main": "dist/app.js",
   "type": "commonjs",

--- a/src/services/discord/commands/ReloadCommand.ts
+++ b/src/services/discord/commands/ReloadCommand.ts
@@ -14,7 +14,7 @@ export async function handleReloadCommand(message: Message, args: string[], serv
 
     // セサミの施錠状態のメッセージも更新する
     const { sesame } = services;
-    sesame.loadSesameDeviceStatusMessage();
+    sesame.loadSesameLockStatusMessage();
 
     message.reply('config をリロードしました');
   } catch (error) {

--- a/src/services/discord/commands/SesameCommand.ts
+++ b/src/services/discord/commands/SesameCommand.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { Message } from 'discord.js';
-import { Services, StatusMessage } from '../../../types/types';
+import { Services } from '../../../types/types';
 import { logger } from '../../../utils/logger';
 
 export async function handleSesameStatusCommand(
@@ -12,7 +12,9 @@ export async function handleSesameStatusCommand(
     const { sesame } = services;
     const status = await sesame.getSesameDeviceStatus();
     const dateStr = format(new Date(status.timestamp), 'yyyy-MM-dd HH:mm:ss');
-    message.reply(`施錠状態: ${StatusMessage[status.lockStatus]}, タイムスタンプ：${dateStr}`);
+    message.reply(
+      `施錠状態: ${sesame.getSesameLockStatusMessage(status.lockStatus)}, タイムスタンプ：${dateStr}`
+    );
   } catch (error) {
     logger.error('施錠状態を取得できませんでした ' + error);
     message.reply('施錠状態を取得できませんでした ' + error);

--- a/src/services/discord/sesameDiscordService.ts
+++ b/src/services/discord/sesameDiscordService.ts
@@ -73,7 +73,7 @@ export class SesameDiscordService {
       this.updateChannelPermission(voiceChannel);
 
       // ボイスチャンネルの名前を取得
-      const channelName = `倉庫｜${sesame.getSesameDeviceStatusMessage(lockStatus)}`;
+      const channelName = `倉庫｜${sesame.getSesameLockStatusMessage(lockStatus)}`;
 
       // ボイスチャンネルの名前を更新
       if (voiceChannel.name !== channelName) {

--- a/src/services/sesame/sesameService.ts
+++ b/src/services/sesame/sesameService.ts
@@ -36,16 +36,16 @@ export class SesameService {
       throw new Error('Configuration not found for Sesame API');
     }
 
-    this.loadSesameDeviceStatusMessage();
+    this.loadSesameLockStatusMessage();
 
     console.log('SesameService の初期化が終了しました。');
   }
 
-  public getSesameDeviceStatusMessage(status: SesameLockStatus): string {
+  public getSesameLockStatusMessage(status: SesameLockStatus): string {
     return this.lockStatusMessage[status];
   }
 
-  public loadSesameDeviceStatusMessage() {
+  public loadSesameLockStatusMessage() {
     this.lockStatusMessage = {
       [SesameLockStatus.Locked]: config.getConfig('sesame_message_when_locked'),
       [SesameLockStatus.Unlocked]: config.getConfig('sesame_message_when_unlocked'),


### PR DESCRIPTION
- メソッド名を `getSesameDeviceStatusMessage` から `getSesameLockStatusMessage` に変更
- `loadSesameDeviceStatusMessage` を `loadSesameLockStatusMessage` にリネーム
- 関連するコマンドとサービスのメソッド呼び出しを更新
- パッケージバージョンを 2.3.8a に更新