### PR TITLE
2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glineze-node-typescript",
-  "version": "2.3.8a",
+  "version": "2.4.0",
   "description": "",
   "main": "dist/app.js",
   "type": "commonjs",
@@ -15,28 +15,28 @@
   "devDependencies": {
     "@types/eslint": "~9.6.1",
     "@types/eslint-config-prettier": "~6.11.3",
-    "@types/express": "^5.0.0",
-    "@types/node": "^22.13.10",
+    "@types/express": "^5.0.5",
+    "@types/node": "^24.10.0",
     "@types/node-cron": "^3.0.11",
-    "@typescript-eslint/eslint-plugin": "^8.26.0",
-    "@typescript-eslint/parser": "^8.26.0",
-    "eslint": "^9.22.0",
-    "eslint-config-prettier": "^10.1.1",
-    "eslint-plugin-prettier": "^5.2.3",
-    "prettier": "^3.5.3",
-    "ts-loader": "^9.5.2",
+    "@typescript-eslint/eslint-plugin": "^8.46.3",
+    "@typescript-eslint/parser": "^8.46.3",
+    "eslint": "^9.39.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.4",
+    "prettier": "^3.6.2",
+    "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@date-fns/tz": "^1.2.0",
-    "@notionhq/client": "^2.2.16",
-    "axios": "^1.8.2",
+    "@date-fns/tz": "^1.4.1",
+    "@notionhq/client": "^5.3.0",
+    "axios": "^1.13.2",
     "date-fns": "^4.1.0",
-    "discord.js": "^14.18.0",
-    "dotenv": "^16.4.7",
-    "express": "^4.21.2",
-    "node-cron": "^3.0.3",
+    "discord.js": "^14.24.2",
+    "dotenv": "^17.2.3",
+    "express": "^5.1.0",
+    "node-cron": "^4.2.1",
     "tsconfig-paths": "^4.2.0"
   }
 }

--- a/src/services/discord/commands/index.ts
+++ b/src/services/discord/commands/index.ts
@@ -24,12 +24,13 @@ export const commandMap = new Map<
 
 /**
  * メッセージからコマンドを判定し、対応する関数を実行する
+ * @returns コマンドが認識されて実行された場合はtrue、そうでない場合はfalse
  */
-export async function handleCommand(message: Message, services: Services): Promise<void> {
+export async function handleCommand(message: Message, services: Services): Promise<boolean> {
   const content = message.content.trim();
 
   // 先頭が '!' でなければコマンドとして扱わない
-  if (!content.startsWith('!')) return;
+  if (!content.startsWith('!')) return false;
 
   // "!countdown send" のように、文字列をパース
   const [commandWithBang, ...args] = content.slice(1).split(' ');
@@ -40,9 +41,13 @@ export async function handleCommand(message: Message, services: Services): Promi
   if (executor) {
     try {
       await executor(message, args, services);
+      return true;
     } catch (error) {
       logger.error(`コマンド実行時にエラーが発生しました: ${error}`);
       await message.reply('コマンド実行時にエラーが発生しました。管理者に連絡してください。');
+      return true; // エラーでもコマンドは認識されたのでtrueを返す
     }
   }
+
+  return false; // コマンドが見つからなかった場合はfalse
 }

--- a/src/services/discord/messageHandler.ts
+++ b/src/services/discord/messageHandler.ts
@@ -34,7 +34,11 @@ export class MessageHandler {
     await relayMessage(message);
 
     if (message.content.startsWith('!')) {
-      await handleCommand(message, this.services);
+      const commandRecognized = await handleCommand(message, this.services);
+      // コマンドが認識されなかった場合は、replyShukinStatusを呼び出す
+      if (!commandRecognized) {
+        await replyShukinStatus(notion, message);
+      }
     } else {
       await replyShukinStatus(notion, message);
     }

--- a/src/services/notion/practiceService.ts
+++ b/src/services/notion/practiceService.ts
@@ -1,12 +1,15 @@
 import { tz } from '@date-fns/tz';
 import { Client } from '@notionhq/client';
-import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { addDays, format } from 'date-fns';
 import { config } from '../../config';
 import { Practice } from '../../types/types';
 import { replaceEnglishDayWithJapanese } from '../../utils/dateUtils';
 import { logger } from '../../utils/logger';
-import { getRelationPropertyValue, getStringPropertyValue } from '../../utils/notionUtils';
+import {
+  getRelationPropertyValue,
+  getStringPropertyValue,
+  queryAllDatabasePages,
+} from '../../utils/notionUtils';
 
 export class PracticeService {
   private client: Client;
@@ -26,12 +29,10 @@ export class PracticeService {
 
     try {
       const databaseId = config.getConfig('practice_databaseid');
-      const response = await this.client.databases.query({
-        database_id: databaseId,
-        filter: { property: '日付', date: { equals: formattedDate } },
+      const pages = await queryAllDatabasePages(this.client, databaseId, {
+        property: '日付',
+        date: { equals: formattedDate },
       });
-
-      const pages = response.results as PageObjectResponse[];
       const practices: Practice[] = [];
 
       for (const page of pages) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates Notion DB queries to the Data Sources API with a new `queryAllDatabasePages`, updates Discord command handling to return recognition status with DM fallback, and bumps version/dependencies.
> 
> - **Notion**:
>   - **API Migration**: Replace database queries with Data Sources API (`client.dataSources.retrieve/query`).
>   - **Utility**: Add/refactor `queryAllDatabasePages` to resolve `data_source_id` and page through results; update `Status` retrieval to use data sources.
>   - **Services**: Update `MemberService` and `PracticeService` to use `queryAllDatabasePages` and remove direct `databases.query` usage.
> - **Discord**:
>   - **Command Handling**: `handleCommand` now returns `boolean` indicating recognition; DM handler falls back to `replyShukinStatus` when no command matched.
> - **Dependencies/Version**:
>   - Bump app to `2.4.0` and upgrade key packages (`express@5`, `@notionhq/client@5.x`, `discord.js`, `axios`, ESLint/TS toolchain).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ab134ad8cebf5627e39ec7745b3878ccb32ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->