### PR TITLE
chore: Bump package version to 2.4.2 and update Notion parent type check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glineze-node-typescript",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "",
   "main": "dist/app.js",
   "type": "commonjs",

--- a/src/utils/notionUtils.ts
+++ b/src/utils/notionUtils.ts
@@ -85,7 +85,7 @@ async function getStatusPropertyGroup(
   page: PageObjectResponse,
   propertyKey: string
 ): Promise<StatusPropertyType> {
-  if (page.parent.type === 'database_id') {
+  if (page.parent.type === 'data_source_id') {
     // page から key に該当するステータスプロパティを取得する
     let statusId: string;
     for (const [key, property] of Object.entries(page.properties)) {


### PR DESCRIPTION
- Updated package version from 2.4.1 to 2.4.2
- Changed parent type check in notionUtils from 'database_id' to 'data_source_id' for improved accuracy